### PR TITLE
Fix arena validation and test isolation

### DIFF
--- a/arena/app.py
+++ b/arena/app.py
@@ -30,9 +30,9 @@ import random
 
 SETTINGS = load_settings()
 
-# A Turso-backed deploy is production: refuse to start if the anti-abuse secrets
-# are missing/defaulted. Failing open here means forgeable pair nonces (public
-# dev HMAC) and a silently-disabled bot gate — worse than downtime.
+# A Turso-backed deploy is production: refuse to start if required datastore or
+# anti-abuse settings are missing/defaulted. Failing open here means forgeable
+# pair nonces, a silently-disabled bot gate, or an unauthenticated datastore.
 if SETTINGS.use_turso and SETTINGS.missing_prod_secrets:
     raise RuntimeError(
         f"arena refusing to start: {', '.join(SETTINGS.missing_prod_secrets)} not set "
@@ -235,7 +235,7 @@ async def api_vote(request: Request):
     async with httpx.AsyncClient() as hc:
         ts_ok = await turnstile.verify(SETTINGS.turnstile_secret,
                                        body.get("turnstile_token", ""),
-                                       _ip_hash(request), hc)
+                                       None, hc)
 
     both_played = bool(body.get("both_played"))
     ip_hash = _ip_hash(request)

--- a/arena/config.py
+++ b/arena/config.py
@@ -31,15 +31,21 @@ class Settings:
 
     @property
     def missing_prod_secrets(self) -> list:
-        """Anti-abuse secrets still at their insecure dev defaults. Non-empty in a
-        production (Turso-backed) deploy means: nonces are signed with the PUBLIC
-        _DEV_HMAC committed to the repo (pair tokens forgeable) and/or Turnstile
-        verification is silently disabled (bot gate off)."""
+        """Required settings missing from a production Turso-backed deploy.
+
+        A missing HMAC makes pair tokens forgeable, incomplete Turnstile settings
+        silently exclude every vote from Elo, and a missing Turso token prevents
+        the production datastore connection from authenticating.
+        """
         out = []
         if self.hmac_secret == _DEV_HMAC:
             out.append("HMAC_SECRET")
         if not self.turnstile_secret:
             out.append("TURNSTILE_SECRET")
+        if not self.turnstile_sitekey:
+            out.append("TURNSTILE_SITEKEY")
+        if not self.turso_token:
+            out.append("TURSO_TOKEN")
         return out
 
 

--- a/arena/tests/conftest.py
+++ b/arena/tests/conftest.py
@@ -3,6 +3,34 @@ import inspect
 import pytest
 
 
+_DEPLOYMENT_ENV = (
+    "ADMIN_TOKEN",
+    "ARENA_DB",
+    "ARENA_LANGS",
+    "ARENA_MANIFEST",
+    "GH_PAGES_BASE",
+    "HMAC_SECRET",
+    "NONCE_MAX_AGE_S",
+    "TURNSTILE_SECRET",
+    "TURNSTILE_SITEKEY",
+    "TURSO_TOKEN",
+    "TURSO_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def isolate_deployment_environment(monkeypatch):
+    """Keep tests independent of local/prod arena credentials.
+
+    export_votes intentionally loads arena/.env for CLI convenience. Disabling
+    dotenv here also prevents that process-global load from leaking into tests
+    that reload arena.app later in the same pytest process.
+    """
+    for key in _DEPLOYMENT_ENV:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("PYTHON_DOTENV_DISABLED", "1")
+
+
 def pytest_collection_modifyitems(items):
     for item in items:
         if isinstance(item, pytest.Function) and inspect.iscoroutinefunction(item.function):

--- a/arena/tests/test_config.py
+++ b/arena/tests/test_config.py
@@ -29,3 +29,20 @@ def test_env_overrides():
 def test_langs_all_means_none():
     s = load_settings(env={"ARENA_LANGS": "all"})
     assert s.langs is None
+
+
+def test_turso_requires_all_production_secrets():
+    s = load_settings(env={"TURSO_URL": "libsql://db.example"})
+    assert s.missing_prod_secrets == [
+        "HMAC_SECRET", "TURNSTILE_SECRET", "TURNSTILE_SITEKEY", "TURSO_TOKEN"]
+
+
+def test_turso_accepts_complete_production_secrets():
+    s = load_settings(env={
+        "TURSO_URL": "libsql://db.example",
+        "TURSO_TOKEN": "db-token",
+        "HMAC_SECRET": "hmac-secret",
+        "TURNSTILE_SECRET": "turnstile-secret",
+        "TURNSTILE_SITEKEY": "turnstile-sitekey",
+    })
+    assert s.missing_prod_secrets == []

--- a/arena/tests/test_turnstile.py
+++ b/arena/tests/test_turnstile.py
@@ -7,6 +7,7 @@ def _client(payload, capture=None):
     def handler(request: httpx.Request) -> httpx.Response:
         if capture is not None:
             capture["url"] = str(request.url)
+            capture["body"] = request.content.decode()
         return httpx.Response(200, json=payload)
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
@@ -35,3 +36,19 @@ async def test_network_error_is_false():
         raise httpx.ConnectError("down")
     async with httpx.AsyncClient(transport=httpx.MockTransport(boom)) as client:
         assert await verify("secret", "tok", "1.2.3.4", client) is False
+
+
+@pytest.mark.asyncio
+async def test_remote_ip_is_omitted_when_unknown():
+    capture = {}
+    async with _client({"success": True}, capture) as client:
+        assert await verify("secret", "tok", None, client) is True
+    assert "remoteip" not in capture["body"]
+
+
+@pytest.mark.asyncio
+async def test_remote_ip_is_forwarded_when_provided():
+    capture = {}
+    async with _client({"success": True}, capture) as client:
+        assert await verify("secret", "tok", "1.2.3.4", client) is True
+    assert "remoteip=1.2.3.4" in capture["body"]

--- a/arena/turnstile.py
+++ b/arena/turnstile.py
@@ -5,7 +5,7 @@ import httpx
 SITEVERIFY = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 
 
-async def verify(secret: str, token: str, remoteip: str,
+async def verify(secret: str, token: str, remoteip: str | None,
                  client: httpx.AsyncClient | None) -> bool:
     """True iff the Turnstile token is valid. Empty secret disables the gate."""
     if not secret:
@@ -13,10 +13,10 @@ async def verify(secret: str, token: str, remoteip: str,
     if not token or client is None:
         return False
     try:
-        resp = await client.post(
-            SITEVERIFY,
-            data={"secret": secret, "response": token, "remoteip": remoteip},
-            timeout=5.0)
+        data = {"secret": secret, "response": token}
+        if remoteip:
+            data["remoteip"] = remoteip
+        resp = await client.post(SITEVERIFY, data=data, timeout=5.0)
         return bool(resp.json().get("success"))
     except (httpx.HTTPError, ValueError):
         return False


### PR DESCRIPTION
## What changed

- stop sending the anonymized IP hash as Cloudflare Turnstile's `remoteip`
- omit `remoteip` when no trusted client IP is available
- require the Turnstile sitekey and Turso token in production configuration
- isolate arena tests from developer and production environment variables
- add regression coverage for Siteverify payloads and production settings

## Why

The arena passed a 16-character SHA-256 fragment where Siteverify accepts an IP address. Separately, `export_votes` intentionally loads `arena/.env`; during a full local test run that process-global state leaked into later app reloads and made results depend on the developer's credentials.

## Impact

Turnstile receives a valid request payload, incomplete production deployments fail clearly at startup, and the arena suite is deterministic even when a local `.env` exists.

## Validation

- `venvs/arena/Scripts/python.exe -m pytest arena/tests -q -p no:cacheprovider --basetemp scratch_pr1_pytest` — 79 passed
- `python -m compileall -q arena`
- `git diff --check`
