### PR TITLE
Add continuous integration baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PYTHON_DOTENV_DISABLED: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install developer dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run unit tests
+        run: python -m pytest -q
+
+      - name: Compile Python sources
+        run: >-
+          python -m compileall -q
+          bench.py compare.py harness.py merge.py publish.py report.py speak.py
+          arena runners scoring
+
+      - name: Check critical static errors
+        run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.pytest.ini_options]
+testpaths = ["arena/tests", "scoring/tests"]
+markers = [
+    "asyncio: coroutine test executed by arena/tests/conftest.py",
+]
+
+[tool.ruff]
+target-version = "py311"
+extend-exclude = [
+    ".devkit",
+    "_gh-pages",
+    "naq_lab",
+    "results",
+    "venvs",
+]
+
+[tool.ruff.lint]
+# Begin with correctness checks that the existing repository can enforce cleanly.
+# Formatting and broader pyflakes cleanup can be enabled incrementally.
+select = ["E9", "F63", "F7", "F82"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r arena/requirements-dev.txt
+jiwer==4.0.0
+numpy==2.3.1
+ruff==0.12.4


### PR DESCRIPTION
## What changed

- add a pinned root developer dependency set for arena and scoring tests
- add shared pytest configuration and register the repository's async marker
- establish a critical-error Ruff baseline without forcing a broad style rewrite
- run tests, compilation, and Ruff in GitHub Actions on Python 3.11
- disable local dotenv loading in CI and cancel superseded workflow runs

## Why

The repository had substantial unit coverage but no root test command or automated enforcement. Contributors needed to infer multiple environments, and regressions could reach `master` without running either suite.

## Impact

`python -m pytest -q` becomes the canonical unit-test command after installing `requirements-dev.txt`. Pull requests receive a fast, reproducible correctness baseline while existing non-critical lint debt can be addressed incrementally.

## Validation

- `python -m pytest -q -p no:cacheprovider --basetemp scratch_pr2_pytest` — 122 passed
- `ruff check .` — passed
- repository-wide Python compilation — passed
- `pyproject.toml` parsed with Python's `tomllib`
- `git diff --check`
