### PR TITLE
Guard model registry metadata drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Interactive feel-test: `python speak.py kokoro`. One-shot A/B comparison: `pytho
 
 ---
 
-## Models tracked (57)
+## Models tracked (58)
 
 #### Predefined voices
 
@@ -164,7 +164,7 @@ Full per-model gotchas + license details: **[docs/known-issues.md](docs/known-is
 
 ## Voice cloning
 
-**42 of the 57 tracked models can clone** a voice from a reference clip. Three reference formats supported (wav only / wav + transcript / HF-gated wav). Drop a reference into `reference/`, then `python bench.py --reference reference/myvoice.wav`.
+**42 of the 58 tracked models can clone** a voice from a reference clip. Three reference formats supported (wav only / wav + transcript / HF-gated wav). Drop a reference into `reference/`, then `python bench.py --reference reference/myvoice.wav`.
 
 Reference-format docs + the blind-vote cloning ranking (28 of 32 cloning models, 397 votes, human-preference A/B): **[docs/cloning.md](docs/cloning.md)**.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,10 +55,16 @@ Runners communicate via JSON lines so each model can live in its own conflicting
    - Single-shot mode: `--text TEXT --out PATH --runs N` → one JSON line per run on stdout: `{"ok": true, "run_index": N, "ttfa_ms": ..., "gen_s": ..., "audio_s": ..., "peak_mem_mb": ..., "peak_vram_mb": ...}`
    - REPL mode: `--stdin` → on startup emit `{"ready": true}` after model load, then per stdin line: `{"text": "...", "out": "path.wav"}` → respond with one JSON line per generation
    - Use the shared helper: `import _meminfo` near the top of the runner; call `_meminfo.reset_peak(args.device)` before generation and spread `**_meminfo.sample(args.device)` into the success JSON
-3. Add a row to `MODELS` in `bench.py` and `speak.py`.
-4. Test: `python bench.py --models <name> --prompts 1 --runs 1`
+3. Add one row to the shared `MODELS` registry in `harness.py`.
+4. Add the model's display, size, source, kind, release, sample-rate,
+   expressive-control, license, and language metadata in `report.py`.
+5. Run the registry guardrail and a one-cell smoke benchmark:
+   - `python -m pytest scoring/tests/test_capabilities.py`
+   - `python bench.py --models <name> --prompts 1 --runs 1`
 
-The two existing runners (`pocket_runner.py`, `neutts_runner.py`) are ~150 lines each — short enough to copy and adapt.
+Use the closest existing runner as a protocol template; model APIs differ enough
+that copying a runner with similar reference-audio and device behavior is safer
+than starting from an arbitrary one.
 
 ---
 

--- a/scoring/tests/test_capabilities.py
+++ b/scoring/tests/test_capabilities.py
@@ -5,25 +5,45 @@ without capability data (SR / Expressive / License / Langs / ...) fails here, an
 the curated cross-lingual flag can't drift onto a model that can't support it.
 """
 import importlib
+import re
+from pathlib import Path
 
 report = importlib.import_module("report")
 harness = importlib.import_module("harness")
 publish = importlib.import_module("publish")
 
 TRACKED = [row[0] for row in harness.MODELS]
+TRACKED_SET = set(TRACKED)
+ROOT = Path(__file__).resolve().parents[2]
 
-CAP_DICTS = ("MODEL_SR", "MODEL_EXPRESSIVE", "MODEL_LICENSE", "MODEL_LANGS",
-             "MODEL_SIZE", "MODEL_KIND", "MODEL_RELEASE", "MODEL_URL")
+CAP_DICTS = ("MODEL_DISPLAY_NAMES", "MODEL_SR", "MODEL_EXPRESSIVE",
+             "MODEL_LICENSE", "MODEL_LANGS", "MODEL_SIZE", "MODEL_KIND",
+             "MODEL_RELEASE", "MODEL_URL")
 
 
-def test_every_tracked_model_has_all_capability_data():
-    missing = {}
+def test_capability_data_matches_registry_exactly():
+    drift = {}
     for name in CAP_DICTS:
-        d = getattr(report, name)
-        gaps = [m for m in TRACKED if m not in d]
-        if gaps:
-            missing[name] = gaps
-    assert not missing, f"capability data gaps: {missing}"
+        keys = set(getattr(report, name))
+        missing = sorted(TRACKED_SET - keys)
+        stale = sorted(keys - TRACKED_SET)
+        if missing or stale:
+            drift[name] = {"missing": missing, "stale": stale}
+    assert not drift, f"capability data drift: {drift}"
+
+
+def test_readme_model_counts_match_registry():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    tracked_match = re.search(r"^## Models tracked \((\d+)\)$", readme, re.MULTILINE)
+    cloning_match = re.search(
+        r"\*\*(\d+) of the (\d+) tracked models can clone\*\*", readme)
+    assert tracked_match, "README is missing the tracked-model count"
+    assert cloning_match, "README is missing the cloning-model count"
+
+    clone_capable = sum(row[6] is not False for row in harness.MODELS)
+    assert int(tracked_match.group(1)) == len(TRACKED)
+    assert int(cloning_match.group(1)) == clone_capable
+    assert int(cloning_match.group(2)) == len(TRACKED)
 
 
 def test_crosslingual_only_for_cloners():


### PR DESCRIPTION
## What changed

- correct the README's tracked-model total from 57 to 58
- keep the cloning count denominator in sync with the registry
- update contributor instructions to point to the shared `harness.MODELS` registry
- document the full metadata checklist for adding a model
- strengthen capability tests to reject both missing and stale metadata keys
- derive and verify README model counts directly from the harness registry

## Why

The shared registry already contained 58 models, while public documentation still reported 57. Existing coverage detected missing capability entries but could not detect stale keys or documentation-count drift.

## Impact

Future model additions and removals fail a focused test until report metadata and README totals agree with the source-of-truth registry. Contributors also get an accurate model-add checklist.

## Validation

- `python -m pytest scoring/tests/test_capabilities.py -q` — 8 passed
- `python -m pytest scoring/tests -q` — 48 passed
- `ruff check scoring/tests/test_capabilities.py` — passed
- `git diff --check`
